### PR TITLE
fix: Rollback deprecation of node-exporter

### DIFF
--- a/charts/oaas-observability/Chart.lock
+++ b/charts/oaas-observability/Chart.lock
@@ -6,8 +6,8 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   version: 4.1.1
 - name: prometheus-node-exporter
-  repository: https://prometheus-community.github.io/helm-charts
-  version: 2.3.0
+  repository: file://../prometheus-node-exporter
+  version: 1.0.5
 - name: prometheus-operator
   repository: file://../prometheus-operator
   version: 1.0.8
@@ -20,5 +20,5 @@ dependencies:
 - name: promtail
   repository: https://grafana.github.io/helm-charts
   version: 3.5.1
-digest: sha256:f9c639c66a7bf1cb0fb692438734cc1fc972a7740b5f622146038b5eaa06980e
-generated: "2021-12-10T07:32:26.795869+01:00"
+digest: sha256:84eba36afc22ba37b2fce605c2f5114ed8156bb32c9acc4c38b4994732710ff3
+generated: "2021-12-10T09:20:16.464403+01:00"

--- a/charts/oaas-observability/Chart.yaml
+++ b/charts/oaas-observability/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart to deploy obeservability stack on Kubernetes
 home: https://github.com/neticdk/k8s-oaas-observability
 sources:
   - https://github.com/neticdk/k8s-oaas-observability
-version: "2.0.21"
+version: "2.0.22"
 maintainers:
   - name: langecode
     email: tal@netic.dk
@@ -20,8 +20,8 @@ dependencies:
     version: 4.1.1
     repository: https://prometheus-community.github.io/helm-charts
   - name: prometheus-node-exporter
-    version: 2.3.0
-    repository: https://prometheus-community.github.io/helm-charts
+    version: "*"
+    repository: file://../prometheus-node-exporter
     condition: nodeExporter.enabled
   - name: prometheus-operator
     version: "*"

--- a/charts/oaas-observability/README.md
+++ b/charts/oaas-observability/README.md
@@ -1,6 +1,6 @@
 # oaas-observability
 
-![Version: 2.0.21](https://img.shields.io/badge/Version-2.0.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.0.22](https://img.shields.io/badge/Version-2.0.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart to deploy obeservability stack on Kubernetes
 
@@ -31,12 +31,12 @@ $ helm install my-release netic-oaas/oaas-observability
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../otel-operator | otel-operator | * |
+| file://../prometheus-node-exporter | prometheus-node-exporter | * |
 | file://../prometheus-operator | prometheus-operator | * |
 | https://grafana.github.io/helm-charts | grafana | 6.18.2 |
 | https://grafana.github.io/helm-charts | promtail | 3.5.1 |
 | https://packages.timber.io/helm/latest | vector-agent | 0.17.0 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 4.1.1 |
-| https://prometheus-community.github.io/helm-charts | prometheus-node-exporter | 2.3.0 |
 
 ## Configuration
 

--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -1,13 +1,9 @@
 apiVersion: v1
-appVersion: 1.0.1
-description: |
-  A Helm chart for prometheus node-exporter. Since this is now part of the Prometheus community
-  Helm charts this has been deprecated and wont be maintained.
-  See https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-node-exporter
+appVersion: 1.3.1
+description: A Helm chart for installing Prometheus node-exporter as Kubernetes daemonset.
 name: prometheus-node-exporter
 home: https://github.com/prometheus/node_exporter
-version: 1.0.4
-deprecated: true
+version: 1.0.5
 sources:
 - https://github.com/prometheus/node_exporter
 - https://github.com/neticdk/k8s-oaas-observability/tree/main/charts/prometheus-node-exporter
@@ -15,3 +11,6 @@ keywords:
 - node-exporter
 - prometheus
 - exporter
+maintainers:
+- name: langecode
+  email: tal@netic.dk

--- a/charts/prometheus-node-exporter/README.md
+++ b/charts/prometheus-node-exporter/README.md
@@ -2,11 +2,9 @@
 
 # prometheus-node-exporter
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
-A Helm chart for prometheus node-exporter. Since this is now part of the Prometheus community
-Helm charts this has been deprecated and wont be maintained.
-See https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-node-exporter
+A Helm chart for installing Prometheus node-exporter as Kubernetes daemonset.
 
 **Homepage:** <https://github.com/prometheus/node_exporter>
 
@@ -61,7 +59,7 @@ The following table lists the configurable parameters of the Node Exporter chart
 | hostNetwork | bool | `true` | Whether to expose the service to the host network |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"quay.io/prometheus/node-exporter"` | Image repository |
-| image.tag | string | `"v1.0.1"` | Image tag |
+| image.tag | string | `nil` | Image tag - default to version in Chart.yaml |
 | namespaceOverride | string | `""` | Override the deployment namespace @default will be set to `.Release.Namespace` if not set |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | podAnnotations | object | `{}` | Annotations to be added to node exporter pods |

--- a/charts/prometheus-node-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-node-exporter/templates/_helpers.tpl
@@ -33,6 +33,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "prometheus-node-exporter.metaLabels" }}
 helm.sh/chart: {{ template "prometheus-node-exporter.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
 {{- if .Values.podLabels}}
 {{ toYaml .Values.podLabels }}
 {{- end }}
@@ -72,3 +75,14 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
     {{- .Release.Namespace -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Resolve the actual image tag to use.
+*/}}
+{{- define "prometheus-node-exporter.imageTag" -}}
+{{- if .Values.image.tag }}
+{{- .Values.image.tag }}
+{{- else }}
+{{- printf "v%s" .Chart.AppVersion }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
 {{- end }}
       containers:
         - name: node-exporter
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ include "prometheus-node-exporter.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --path.procfs=/host/proc

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -4,8 +4,8 @@
 image:
   # -- Image repository
   repository: quay.io/prometheus/node-exporter
-  # -- Image tag
-  tag: v1.0.1
+  # -- Image tag - default to version in Chart.yaml
+  tag:
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
The node-exporter in Prometheus community charts is not rendering compliant labels - we need to keep a Netic version for now.