### PR TITLE
feat: allow additional scrape config for prometheus

### DIFF
--- a/charts/oaas-observability/Chart.yaml
+++ b/charts/oaas-observability/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart to deploy obeservability stack on Kubernetes
 home: https://github.com/neticdk/k8s-oaas-observability
 sources:
   - https://github.com/neticdk/k8s-oaas-observability
-version: "2.0.29"
+version: "2.0.30"
 maintainers:
   - name: langecode
     email: tal@netic.dk

--- a/charts/oaas-observability/README.md
+++ b/charts/oaas-observability/README.md
@@ -1,6 +1,6 @@
 # oaas-observability
 
-![Version: 2.0.29](https://img.shields.io/badge/Version-2.0.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.0.30](https://img.shields.io/badge/Version-2.0.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart to deploy obeservability stack on Kubernetes
 
@@ -267,6 +267,7 @@ $ helm install my-release netic-oaas/oaas-observability
 | prometheus.podDisruptionBudget.maxUnavailable | string | `""` |  |
 | prometheus.podDisruptionBudget.minAvailable | int | `1` |  |
 | prometheus.podSecurityPolicy.allowedCapabilities | list | `[]` |  |
+| prometheus.prometheusSpec.additionalScrapeConfigs | list | `[]` |  |
 | prometheus.prometheusSpec.affinity | object | `{}` |  |
 | prometheus.prometheusSpec.alertingEndpoints | list | `[]` |  |
 | prometheus.prometheusSpec.apiserverConfig | object | `{}` |  |

--- a/charts/oaas-observability/templates/prometheus/additionalScrapeConfigs.yaml
+++ b/charts/oaas-observability/templates/prometheus/additionalScrapeConfigs.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.prometheus.prometheusSpec.additionalScrapeConfigs }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "netic-oaas.fullname" . }}-prometheus-scrape-confg
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "netic-oaas.name" . }}-prometheus-scrape-confg
+{{ include "netic-oaas.labels" . | indent 4 }}
+data:
+  additional-scrape-configs.yaml: {{ tpl (toYaml .Values.prometheus.prometheusSpec.additionalScrapeConfigs) $ | b64enc | quote }}
+{{- end }}

--- a/charts/oaas-observability/templates/prometheus/prometheus.yaml
+++ b/charts/oaas-observability/templates/prometheus/prometheus.yaml
@@ -187,6 +187,11 @@ spec:
   imagePullSecrets:
 {{ toYaml .Values.global.imagePullSecrets | indent 4 }}
 {{- end }}
+{{- if .Values.prometheus.prometheusSpec.additionalScrapeConfigs }}
+  additionalScrapeConfigs:
+    name: {{ template "netic-oaas.fullname" . }}-prometheus-scrape-confg
+    key: additional-scrape-configs.yaml
+{{- end }}
 {{- if .Values.prometheus.prometheusSpec.containers }}
   containers:
 {{ toYaml .Values.prometheus.prometheusSpec.containers | indent 4 }}

--- a/charts/oaas-observability/values.yaml
+++ b/charts/oaas-observability/values.yaml
@@ -1051,6 +1051,38 @@ prometheus:
       tag: v2.30.3
     version: v2.30.3
 
+    ## additionalScrapeConfigs for adding scape configs (https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#prometheusspec
+    ##
+    additionalScrapeConfigs: []
+    # - job_name: kube-etcd
+    #   kubernetes_sd_configs:
+    #     - role: node
+    #   scheme: https
+    #   tls_config:
+    #     ca_file:   /etc/prometheus/secrets/etcd-client-cert/etcd-ca
+    #     cert_file: /etc/prometheus/secrets/etcd-client-cert/etcd-client
+    #     key_file:  /etc/prometheus/secrets/etcd-client-cert/etcd-client-key
+    #   relabel_configs:
+    #   - action: labelmap
+    #     regex: __meta_kubernetes_node_label_(.+)
+    #   - source_labels: [__address__]
+    #     action: replace
+    #     targetLabel: __address__
+    #     regex: ([^:;]+):(\d+)
+    #     replacement: ${1}:2379
+    #   - source_labels: [__meta_kubernetes_node_name]
+    #     action: keep
+    #     regex: .*mst.*
+    #   - source_labels: [__meta_kubernetes_node_name]
+    #     action: replace
+    #     targetLabel: node
+    #     regex: (.*)
+    #     replacement: ${1}
+    #   metric_relabel_configs:
+    #   - regex: (kubernetes_io_hostname|failure_domain_beta_kubernetes_io_region|beta_kubernetes_io_os|beta_kubernetes_io_arch|beta_kubernetes_io_instance_type|failure_domain_beta_kubernetes_io_zone)
+    #     action: labeldrop
+
     ## Tolerations for use with node taints
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
     ##


### PR DESCRIPTION
Allow adding the `additionalScrapeConfigs` from Promerheus Spec ( https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#prometheusspec ).

This enables adding scrape config that is custom and not suitable for serviceMonitors/podMonitors.