### PR TITLE
:sparkles: add support for prometheus probe selectors

### DIFF
--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -60,6 +60,8 @@ The following table lists the configurable parameters of the Node Exporter chart
 | prometheusSpec.image | string | `"quay.io/prometheus/prometheus:v2.48.1"` |  |
 | prometheusSpec.podMonitorNamespaceSelector | object | `{}` |  |
 | prometheusSpec.podMonitorSelector | object | `{}` |  |
+| prometheusSpec.probeNamespaceSelector | object | `{}` |  |
+| prometheusSpec.probeSelector | object | `{}` |  |
 | prometheusSpec.priorityClassName | string | `"secure-cloud-stack-technical-operations-critical"` |  |
 | prometheusSpec.remoteWrite | list | `[]` |  |
 | prometheusSpec.replicas | int | `2` |  |

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -60,9 +60,9 @@ The following table lists the configurable parameters of the Node Exporter chart
 | prometheusSpec.image | string | `"quay.io/prometheus/prometheus:v2.48.1"` |  |
 | prometheusSpec.podMonitorNamespaceSelector | object | `{}` |  |
 | prometheusSpec.podMonitorSelector | object | `{}` |  |
+| prometheusSpec.priorityClassName | string | `"secure-cloud-stack-technical-operations-critical"` |  |
 | prometheusSpec.probeNamespaceSelector | object | `{}` |  |
 | prometheusSpec.probeSelector | object | `{}` |  |
-| prometheusSpec.priorityClassName | string | `"secure-cloud-stack-technical-operations-critical"` |  |
 | prometheusSpec.remoteWrite | list | `[]` |  |
 | prometheusSpec.replicas | int | `2` |  |
 | prometheusSpec.resources | object | `{}` |  |

--- a/charts/prometheus/templates/prometheus.yaml
+++ b/charts/prometheus/templates/prometheus.yaml
@@ -12,6 +12,8 @@ spec:
   ruleSelector: {{ .Values.prometheusSpec.ruleSelector | toYaml | nindent 4 }}
   podMonitorNamespaceSelector: {{ .Values.prometheusSpec.podMonitorNamespaceSelector | toYaml | nindent 4 }}
   podMonitorSelector: {{ .Values.prometheusSpec.podMonitorSelector | toYaml | nindent 4 }}
+  probeNamespaceSelector: {{ .Values.prometheusSpec.probeNamespaceSelector | toYaml | nindent 4 }}
+  probeSelector: {{ .Values.prometheusSpec.probeSelector | toYaml | nindent 4 }}
   image: {{ .Values.prometheusSpec.image }}
   version: {{ .Values.prometheusSpec.version | quote }}
   resources: {{ .Values.prometheusSpec.resources | toYaml | nindent 4 }}

--- a/charts/prometheus/templates/prometheus.yaml
+++ b/charts/prometheus/templates/prometheus.yaml
@@ -12,8 +12,14 @@ spec:
   ruleSelector: {{ .Values.prometheusSpec.ruleSelector | toYaml | nindent 4 }}
   podMonitorNamespaceSelector: {{ .Values.prometheusSpec.podMonitorNamespaceSelector | toYaml | nindent 4 }}
   podMonitorSelector: {{ .Values.prometheusSpec.podMonitorSelector | toYaml | nindent 4 }}
-  probeNamespaceSelector: {{ .Values.prometheusSpec.probeNamespaceSelector | toYaml | nindent 4 }}
-  probeSelector: {{ .Values.prometheusSpec.probeSelector | toYaml | nindent 4 }}
+  {{ with .Values.prometheusSpec.probeNamespaceSelector }}
+  probeNamespaceSelector:
+    {{- . | toYaml | nindent 4 }}
+  {{ end }}
+  {{ with .Values.prometheusSpec.probeSelector }}
+  probeSelector:
+    {{- . | toYaml | nindent 4 }}
+  {{ end }}
   image: {{ .Values.prometheusSpec.image }}
   version: {{ .Values.prometheusSpec.version | quote }}
   resources: {{ .Values.prometheusSpec.resources | toYaml | nindent 4 }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,6 +18,8 @@ prometheusSpec:
   ruleSelector: {}
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
+  probeNamespaceSelector: {}
+  probeSelector: {}
   resources: {}
   externalLabels: {}
   remoteWrite: []


### PR DESCRIPTION
Add support for supplying probeSelector and probeNamespaceSelector to the prometheus resource in the prometheus helm chart.